### PR TITLE
Feature [#2] Create Policies Corresponding to Every Model

### DIFF
--- a/app/Console/Commands/BaseCommand.php
+++ b/app/Console/Commands/BaseCommand.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Support\Str;
+use Illuminate\Console\Command;
+use Illuminate\Filesystem\Filesystem;
+
+/**
+ * BaseCommand is an abstract class that provides the common structure
+ * and functionality for commands that generate files dynamically.
+ * The $fileType variable allows customization of the file type (e.g., Policy, Type).
+ */
+abstract class BaseCommand extends Command
+{
+    /**
+     * The Filesystem instance used to handle file operations.
+     *
+     * @var Filesystem
+     */
+    protected Filesystem $files;
+
+    /**
+     * The type of file being created (e.g., 'Policy', 'Type').
+     *
+     * @var string
+     */
+    private string $fileType;
+
+    /**
+     * The exit codes for success and error.
+     * These are used to determine the exit code of the command.
+     * The command will exit with EXIT_SUCCESS_CODE on success and EXIT_ERROR_CODE on error.
+     * 
+     * @var int
+     */
+    private const EXIT_ERROR_CODE = 1;
+    private const EXIT_SUCCESS_CODE = 0;
+
+    /**
+     * BaseCommand constructor.
+     *
+     * @param Filesystem $files The Filesystem instance for file operations.
+     * @param string $fileType The type of file being created (e.g., 'Policy', 'Type').
+     */
+    public function __construct(Filesystem $files, string $fileType)
+    {
+        parent::__construct();
+        $this->files = $files;
+        $this->fileType = $fileType;
+    }
+
+    /**
+     * Abstract method to define the file path for the generated class.
+     *
+     * @param string $name The name of the file.
+     * @return string The file path where the class will be generated.
+     */
+    abstract protected function getFilePath(string $name): string;
+
+    /**
+     * Abstract method to define the content for the generated class file.
+     *
+     * @param string $name The name of the file.
+     * @return string The content that will be written to the class file.
+     */
+    abstract protected function getFileContent(string $name): string;
+
+    /**
+     * Method to generate the class file.
+     *
+     * @param string $name The name of the file being created.
+     * @return void
+     */
+    public function generateFile(string $name): int
+    {
+        $path = $this->getFilePath($name);
+
+        // Normalize path for output
+        $normalizedPath = Str::replace('\\', '/', $path);
+
+        // Check if the file already exists
+        if ($this->files->exists($normalizedPath)) {
+            $this->error("ERROR  {$this->fileType} already exists.");
+            return self::EXIT_ERROR_CODE;
+        }
+
+        // Get the file content
+        $content = $this->getFileContent($name);
+
+        // Write the file
+        $this->files->put($normalizedPath, $content);
+
+        // Output success message
+        $this->info("INFO  {$this->fileType} [{$normalizedPath}] created successfully.");
+
+        return self::EXIT_SUCCESS_CODE;
+    }
+}

--- a/app/Console/Commands/MakeOwnPolicyCommand.php
+++ b/app/Console/Commands/MakeOwnPolicyCommand.php
@@ -2,10 +2,9 @@
 
 namespace App\Console\Commands;
 
-use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
 
-class MakeOwnPolicyCommand extends Command
+class MakeOwnPolicyCommand extends BaseCommand
 {
     /**
      * The name and signature of the console command.
@@ -21,38 +20,52 @@ class MakeOwnPolicyCommand extends Command
      */
     protected $description = 'Create a new policy class file';
 
-    protected Filesystem $files;
-
+    /**
+     * MakeOwnPolicyCommand constructor.
+     */
     public function __construct(Filesystem $files)
     {
-        parent::__construct();
-        $this->files = $files;
+        // Pass 'Policy' as the file type
+        parent::__construct($files, 'Policy');
     }
 
     /**
      * Execute the console command.
      */
-    public function handle(Filesystem $files)
+    public function handle()
     {
         // Get the model argument
         $model = $this->argument('model');
-        $path = app_path("Policies/{$model}Policy.php");
 
-        // Check if the file already exists
-        if ($this->files->exists($path)) {
-            $this->error("ERROR  Policy already exists.");
-            return;
-        }
+        // Generate the policy file
+        return $this->generateFile($model);
+    }
 
-        // Define the file content
-        // Do not indent since it will be written to the file as is
-        $content = <<<PHP
+    /**
+     * Define the file path for the policy class.
+     *
+     * @param string $model The model name.
+     * @return string The file path for the policy.
+     */
+    protected function getFilePath(string $model): string
+    {
+        return app_path("Policies/{$model}Policy.php");
+    }
+
+    /**
+     * Define the file content for the policy class.
+     *
+     * @param string $model The model name.
+     * @return string The content of the policy class file.
+     */
+    protected function getFileContent(string $model): string
+    {
+        return <<<PHP
 <?php
 
 namespace App\Policies;
 
 use App\Models\\$model;
-use App\Models\User;
 
 class {$model}Policy extends BasePolicy
 {
@@ -62,13 +75,5 @@ class {$model}Policy extends BasePolicy
     }
 }
 PHP;
-
-        // Write the file
-        $this->files->put($path, $content);
-
-        // Create the file and write the content
-        $this->files->put($path, $content);
-
-        $this->info("INFO  Policy [{$path}] created successfully.");
     }
 }

--- a/app/Console/Commands/MakeOwnPolicyCommand.php
+++ b/app/Console/Commands/MakeOwnPolicyCommand.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Filesystem\Filesystem;
+
+class MakeOwnPolicyCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'make:own-policy {model}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create a new policy class file';
+
+    protected Filesystem $files;
+
+    public function __construct(Filesystem $files)
+    {
+        parent::__construct();
+        $this->files = $files;
+    }
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(Filesystem $files)
+    {
+        // Get the model argument
+        $model = $this->argument('model');
+        $path = app_path("Policies/{$model}Policy.php");
+
+        // Check if the file already exists
+        if ($this->files->exists($path)) {
+            $this->error("ERROR  Policy already exists.");
+            return;
+        }
+
+        // Define the file content
+        // Do not indent since it will be written to the file as is
+        $content = <<<PHP
+<?php
+
+namespace App\Policies;
+
+use App\Models\\$model;
+use App\Models\User;
+
+class {$model}Policy extends BasePolicy
+{
+    public function model(): string
+    {
+        return {$model}::class;
+    }
+}
+PHP;
+
+        // Write the file
+        $this->files->put($path, $content);
+
+        // Create the file and write the content
+        $this->files->put($path, $content);
+
+        $this->info("INFO  Policy [{$path}] created successfully.");
+    }
+}

--- a/app/Console/Commands/MakeTypesCommand.php
+++ b/app/Console/Commands/MakeTypesCommand.php
@@ -2,10 +2,9 @@
 
 namespace App\Console\Commands;
 
-use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
 
-class MakeTypesCommand extends Command
+class MakeTypesCommand extends BaseCommand
 {
     /**
      * The name and signature of the console command.
@@ -21,12 +20,13 @@ class MakeTypesCommand extends Command
      */
     protected $description = 'Create a new types class file';
 
-    protected Filesystem $files;
-
+    /**
+     * MakeTypesCommand constructor.
+     */
     public function __construct(Filesystem $files)
     {
-        parent::__construct();
-        $this->files = $files;
+        // Pass 'Type' as the file type
+        parent::__construct($files, 'Type');
     }
 
     /**
@@ -36,49 +36,63 @@ class MakeTypesCommand extends Command
     {
         // Get the filename argument
         $filename = $this->argument('filename');
-        $path = app_path("Types/{$filename}.php");
 
-        // Check if the file already exists
-        if ($this->files->exists($path)) {
-            $this->error("ERROR  Type already exists.");
-            return;
-        }
+        // Generate the types file
+        return $this->generateFile($filename);
+    }
 
-        // Define the file content
-        // Do not indent since it will be written to the file as is
-        $content = <<<PHP
+    /**
+     * Define the file path for the types class.
+     *
+     * @param string $filename The filename.
+     * @return string The file path for the types class.
+     */
+    protected function getFilePath(string $filename): string
+    {
+        return app_path("Types/{$filename}.php");
+    }
+
+    /**
+     * Define the file content for the types class.
+     *
+     * @param string $filename The filename.
+     * @return string The content of the types class file.
+     */
+    protected function getFileContent(string $filename): string
+    {
+        return <<<PHP
 <?php
 
 namespace App\Types;
 
 use App\Traits\Makeable;
 
-class {$filename}Type extends BaseType
+class {$filename} extends BaseType
 {
     use Makeable;
 
-    public static function getDefaultPermissions(string \$classname) : array
+    public static function getDefaultPermissions(string \$classname): array
     {
         return [
             //
         ];
     }
 
-    public function setTypes() : array
+    public function setTypes(): array
     {
         return [
             //
         ];
     }
 
-    public function setSelectionTypes() : array
+    public function setSelectionTypes(): array
     {
         return [
             //
         ];
     }
 
-    public function setDefaultColors() : array
+    public function setDefaultColors(): array
     {
         return [
             //
@@ -86,10 +100,5 @@ class {$filename}Type extends BaseType
     }
 }
 PHP;
-
-        // Create the file and write the content
-        $this->files->put($path, $content);
-
-        $this->info("INFO  Type [{$path}] created successfully.");
     }
 }

--- a/app/Policies/BasePolicy.php
+++ b/app/Policies/BasePolicy.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace App\Policies;
+
+use App\Helpers\ExtractClassNameHelper;
+use App\Models\User;
+
+/**
+ * The BasePolicy class serves as an abstract base class for defining 
+ * policies related to user permissions on various models. It handles 
+ * common authorization checks like viewing, creating, updating, and deleting.
+ * Derived classes should implement the `model()` method to specify the model 
+ * they are authorizing actions for.
+ */
+abstract class BasePolicy
+{
+    /**
+     * @var string Holds the name of the model being authorized.
+     */
+    private string $model;
+
+    /**
+     * Abstract method that derived classes must implement to specify the 
+     * model name that the policy applies to.
+     *
+     * @return string The class name of the model.
+     */
+    abstract public function model(): string;
+
+    /**
+     * Create a new policy instance.
+     * 
+     * This constructor uses the ExtractClassNameHelper to extract the base name 
+     * of the model class, allowing for more flexible string-based permission checks.
+     */
+    public function __construct()
+    {
+        $this->model = ExtractClassNameHelper::extract($this->model());
+    }
+
+    /**
+     * Determine whether the user can view any instances of the model.
+     *
+     * @param User $user The user attempting to view models.
+     * @return bool True if the user has permission, false otherwise.
+     */
+    public function viewAny(User $user): bool
+    {
+        return $user->can("view any $this->model");
+    }
+
+    /**
+     * Determine whether the user can view a specific instance of the model.
+     *
+     * @param User $user The user attempting to view the model.
+     * @return bool True if the user has permission, false otherwise.
+     */
+    public function view(User $user): bool
+    {
+        return $user->can("view $this->model");
+    }
+
+    /**
+     * Determine whether the user can create a new instance of the model.
+     *
+     * @param User $user The user attempting to create the model.
+     * @return bool True if the user has permission, false otherwise.
+     */
+    public function create(User $user): bool
+    {
+        return $user->can("create $this->model");
+    }
+
+    /**
+     * Determine whether the user can update a specific instance of the model.
+     *
+     * @param User $user The user attempting to update the model.
+     * @return bool True if the user has permission, false otherwise.
+     */
+    public function update(User $user): bool
+    {
+        return $user->can("update $this->model");
+    }
+
+    /**
+     * Determine whether the user can delete a specific instance of the model.
+     *
+     * @param User $user The user attempting to delete the model.
+     * @return bool True if the user has permission, false otherwise.
+     */
+    public function delete(User $user): bool
+    {
+        return $user->can("delete $this->model");
+    }
+
+    /**
+     * Determine whether the user can restore a previously deleted instance of the model.
+     *
+     * @param User $user The user attempting to restore the model.
+     * @return bool True if the user has permission, false otherwise.
+     */
+    public function restore(User $user): bool
+    {
+        return $user->can("restore $this->model");
+    }
+
+    /**
+     * Determine whether the user can permanently delete a specific instance of the model.
+     *
+     * @param User $user The user attempting to force delete the model.
+     * @return bool True if the user has permission, false otherwise.
+     */
+    public function forceDelete(User $user): bool
+    {
+        return $user->can("force delete $this->model");
+    }
+}

--- a/tests/Unit/Console/Commands/MakeOwnPolicyCommandTest.php
+++ b/tests/Unit/Console/Commands/MakeOwnPolicyCommandTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Tests\Unit\Console\Commands;
+
+use App\Console\Commands\MakeOwnPolicyCommand;
+use Illuminate\Filesystem\Filesystem;
+use Tests\TestCase;
+use Mockery;
+
+class MakeOwnPolicyCommandTest extends TestCase
+{
+    /** @test */
+    public function it_creates_a_policy_file_successfully()
+    {
+        // Arrange: Mock the Filesystem
+        $filesystem = Mockery::mock(Filesystem::class);
+        $this->app->instance(Filesystem::class, $filesystem);
+
+        $modelName = 'TestModel';
+        $filePath = app_path("Policies/{$modelName}Policy.php");
+
+        // Normalize path for assertion
+        $normalizedPath = str_replace('\\', '/', $filePath);
+
+        // Expect the file to not exist
+        $filesystem->shouldReceive('exists')
+            ->once()
+            ->with($normalizedPath)
+            ->andReturn(false);
+
+        // Expect the file to be written
+        $filesystem->shouldReceive('put')
+            ->once()
+            ->with($normalizedPath, Mockery::type('string'));
+
+        // Act: Run the artisan command
+        $this->artisan('make:own-policy', ['model' => $modelName])
+            ->expectsOutput("INFO  Policy [{$normalizedPath}] created successfully.")
+            ->assertExitCode(0);
+    }
+
+    /** @test */
+    public function it_shows_error_if_policy_file_already_exists()
+    {
+        // Arrange
+        $filesystem = Mockery::mock(Filesystem::class);
+        $this->app->instance(Filesystem::class, $filesystem);
+
+        $modelName = 'TestModel';
+        $filePath = app_path("Policies/{$modelName}Policy.php");
+
+        // Normalize path for assertion
+        $normalizedPath = str_replace('\\', '/', $filePath);
+
+        // Expect the file to exist, so the command will not create it
+        $filesystem->shouldReceive('exists')
+            ->once()
+            ->with($normalizedPath)
+            ->andReturn(true);
+
+        // Act
+        $this->artisan('make:own-policy', ['model' => $modelName])
+            ->expectsOutput("ERROR  Policy already exists.")
+            ->assertExitCode(1);
+    }
+}

--- a/tests/Unit/Console/Commands/MakeTypesCommandTest.php
+++ b/tests/Unit/Console/Commands/MakeTypesCommandTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Tests\Unit\Console\Commands;
+
+use App\Console\Commands\MakeOwnPolicyCommand;
+use Illuminate\Filesystem\Filesystem;
+use Tests\TestCase;
+use Mockery;
+
+class MakeTypesCommandTest extends TestCase
+{
+    /** @test */
+    public function it_creates_a_type_file_successfully()
+    {
+        // Arrange: Mock the Filesystem
+        $filesystem = Mockery::mock(Filesystem::class);
+        $this->app->instance(Filesystem::class, $filesystem);
+
+        $filename = 'TestType';
+        $filePath = app_path("Types/{$filename}.php");
+
+        // Normalize path for assertion
+        $normalizedPath = str_replace('\\', '/', $filePath);
+
+        // Expect the file to not exist
+        $filesystem->shouldReceive('exists')
+            ->once()
+            ->with($normalizedPath)
+            ->andReturn(false);
+
+        // Expect the file to be written
+        $filesystem->shouldReceive('put')
+            ->once()
+            ->with($normalizedPath, Mockery::type('string'));
+
+        // Act: Run the artisan command
+        $this->artisan('make:types', ['filename' => $filename])
+            ->expectsOutput("INFO  Type [{$normalizedPath}] created successfully.")
+            ->assertExitCode(0);
+    }
+
+    /** @test */
+    public function it_shows_error_if_type_file_already_exists()
+    {
+        // Arrange
+        $filesystem = Mockery::mock(Filesystem::class);
+        $this->app->instance(Filesystem::class, $filesystem);
+
+        $filename = 'TestType';
+        $filePath = app_path("Types/{$filename}.php");
+
+        // Normalize path for assertion
+        $normalizedPath = str_replace('\\', '/', $filePath);
+
+        // Expect the file to exist, so the command will not create it
+        $filesystem->shouldReceive('exists')
+            ->once()
+            ->with($normalizedPath)
+            ->andReturn(true);
+
+        // Act
+        $this->artisan('make:types', ['filename' => $filename])
+            ->expectsOutput("ERROR  Type already exists.")
+            ->assertExitCode(1);
+    }
+}


### PR DESCRIPTION
Fixes #2

Changes:
- Create a command to create policy depending on the model
```bash
  php artisan make:own-policy [model_name]
```