### PR TITLE
Feature [#8] Create Water Type Resource

### DIFF
--- a/app/Filament/Resources/WaterTypeResource.php
+++ b/app/Filament/Resources/WaterTypeResource.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\WaterTypeResource\Pages;
+use App\Filament\Resources\WaterTypeResource\RelationManagers;
+use App\Models\WaterType;
+use Filament\Forms;
+use Filament\Forms\Form;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\SoftDeletingScope;
+
+class WaterTypeResource extends Resource
+{
+    protected static ?string $model = WaterType::class;
+
+    protected static ?string $navigationIcon = 'heroicon-o-list-bullet';
+
+    protected static bool $shouldRegisterNavigation = false;
+
+    public static function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                Forms\Components\TextInput::make('name')
+                    ->required()
+                    ->maxLength(32),
+            ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('name')
+                    ->searchable(),
+                Tables\Columns\TextColumn::make('created_at')
+                    ->dateTime()
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+                Tables\Columns\TextColumn::make('updated_at')
+                    ->dateTime()
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+                Tables\Columns\TextColumn::make('deleted_at')
+                    ->dateTime()
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+            ])
+            ->filters([
+                Tables\Filters\TrashedFilter::make(),
+            ])
+            ->actions([
+                Tables\Actions\ViewAction::make(),
+                Tables\Actions\EditAction::make(),
+            ])
+            ->bulkActions([
+                Tables\Actions\BulkActionGroup::make([
+                    Tables\Actions\DeleteBulkAction::make(),
+                    Tables\Actions\ForceDeleteBulkAction::make(),
+                    Tables\Actions\RestoreBulkAction::make(),
+                ]),
+            ]);
+    }
+
+    public static function getRelations(): array
+    {
+        return [
+            //
+        ];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListWaterTypes::route('/'),
+            'create' => Pages\CreateWaterType::route('/create'),
+            'view' => Pages\ViewWaterType::route('/{record}'),
+            'edit' => Pages\EditWaterType::route('/{record}/edit'),
+        ];
+    }
+
+    public static function getEloquentQuery(): Builder
+    {
+        return parent::getEloquentQuery()
+            ->withoutGlobalScopes([
+                SoftDeletingScope::class,
+            ]);
+    }
+}

--- a/app/Filament/Resources/WaterTypeResource/Pages/CreateWaterType.php
+++ b/app/Filament/Resources/WaterTypeResource/Pages/CreateWaterType.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Filament\Resources\WaterTypeResource\Pages;
+
+use App\Filament\Resources\WaterTypeResource;
+use Filament\Actions;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateWaterType extends CreateRecord
+{
+    protected static string $resource = WaterTypeResource::class;
+}

--- a/app/Filament/Resources/WaterTypeResource/Pages/EditWaterType.php
+++ b/app/Filament/Resources/WaterTypeResource/Pages/EditWaterType.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Filament\Resources\WaterTypeResource\Pages;
+
+use App\Filament\Resources\WaterTypeResource;
+use Filament\Actions;
+use Filament\Resources\Pages\EditRecord;
+
+class EditWaterType extends EditRecord
+{
+    protected static string $resource = WaterTypeResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\ViewAction::make(),
+            Actions\DeleteAction::make(),
+            Actions\ForceDeleteAction::make(),
+            Actions\RestoreAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/WaterTypeResource/Pages/ListWaterTypes.php
+++ b/app/Filament/Resources/WaterTypeResource/Pages/ListWaterTypes.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\WaterTypeResource\Pages;
+
+use App\Filament\Resources\WaterTypeResource;
+use Filament\Actions;
+use Filament\Resources\Pages\ListRecords;
+
+class ListWaterTypes extends ListRecords
+{
+    protected static string $resource = WaterTypeResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\CreateAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/WaterTypeResource/Pages/ViewWaterType.php
+++ b/app/Filament/Resources/WaterTypeResource/Pages/ViewWaterType.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\WaterTypeResource\Pages;
+
+use App\Filament\Resources\WaterTypeResource;
+use Filament\Actions;
+use Filament\Resources\Pages\ViewRecord;
+
+class ViewWaterType extends ViewRecord
+{
+    protected static string $resource = WaterTypeResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\EditAction::make(),
+        ];
+    }
+}

--- a/app/Models/WaterType.php
+++ b/app/Models/WaterType.php
@@ -5,10 +5,11 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 class WaterType extends Model
 {
-    use HasFactory;
+    use HasFactory, SoftDeletes;
 
     protected $fillable = ['name'];
 

--- a/database/seeders/PermissionSeeder.php
+++ b/database/seeders/PermissionSeeder.php
@@ -5,6 +5,7 @@ namespace Database\Seeders;
 use App\Models\User;
 use Illuminate\Database\Seeder;
 use App\Helpers\RolePermissionFactoryHelper;
+use App\Models\WaterType;
 use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 
 class PermissionSeeder extends Seeder
@@ -15,5 +16,6 @@ class PermissionSeeder extends Seeder
     public function run(): void
     {
         RolePermissionFactoryHelper::make(User::class);
+        RolePermissionFactoryHelper::make(WaterType::class);
     }
 }


### PR DESCRIPTION
This commit adds the WaterTypeResource class and its related pages: CreateWaterType, EditWaterType, ListWaterTypes, and ViewWaterType. The WaterTypeResource class is responsible for managing the WaterType model, and the pages provide functionality for creating, editing, listing, and viewing water types.

The WaterTypeResource class includes a form for creating water types, a table for listing water types with columns for name, creation date, update date, and deletion date, and filters and actions for managing the water types. The pages have header actions for editing, deleting, restoring, and viewing water types.

Additionally, the WaterType model now uses the SoftDeletes trait, allowing for soft deletion of water types.

The PermissionSeeder has also been updated to include the WaterType model in the RolePermissionFactoryHelper.